### PR TITLE
Remove messages from IO testing

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,23 @@
+version: v1.0
+name: AppSignal mio_worker
+agent:
+  machine:
+    type: e1-standard-2
+  containers:
+    - name: main
+      image: registry.semaphoreci.com/rust:1.55
+blocks:
+  - name: 'Default'
+    task:
+      prologue:
+        commands:
+          - checkout
+      jobs:
+        - name: Formatter and linter
+          commands:
+            - rustup component add clippy
+            - cargo fmt --verbose --all -- --check
+            - cargo clippy
+        - name: Build and tests
+          commands:
+            - RUST_LOG=trace cargo test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.59
+
+WORKDIR /Users/luismiguelramirezmela/code/mio-worker
+
+COPY . .
+
+RUN RUST_LOG=trace cargo test --test io -- --nocapture
+
+CMD tail -f /dev/null

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -58,6 +58,7 @@ impl Handler for ServerHandler {
                     let mut received_data = vec![0; 4096];
                     match connection.read(&mut received_data[0..]) {
                         Ok(bytes_read) => {
+                            trace!("Read {} bytes", bytes_read);
                             self.bytes_read.fetch_add(bytes_read, Ordering::SeqCst);
                         }
                         Err(e) => error!("Error reading: {:?}", e),
@@ -103,6 +104,7 @@ impl Handler for ClientHandler {
             }
             // Make a message and write it
             let message = b"aaaaaaaaaa";
+            trace!("Writing message: {}", self.message_count);
             self.stream.write(message).unwrap();
             self.message_count += 1;
         }
@@ -167,6 +169,9 @@ fn test_io() {
     thread::spawn(move || {
         client_worker.run().unwrap();
     });
+
+    client_context.shutdown().unwrap();
+    server_context.shutdown().unwrap();
 
     // Sleep for a bit
     thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
IO testing was performed using the messages as elements of a vector and
then counting them. This is not trustable when using multithreading or
big amounts of data because messages that are expected to be independent
by the tests can be sent into the same buffer.

Now the tests are based on the total bytes read. Making it more
trustable and bombproof.

Semaphore CI is also included.